### PR TITLE
Release 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ The one thing that has changed is that the external apps being able to communica
 
 - Custom app can communicate with another device with the ControlSDK. In this scenario, 
 the ControlSDK on the main device will relay data to the second device.
+
+## Turning off notifications for when internal exceptions occur
+
+Add this to your application class
+
+`ControlSDKService.allowNotificationForExceptions = false`

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext{
     globalBuildToolsVersion = "28.0.3"
     buildNumber = BITRISE_BUILD_NUMBER
     gitHash = getGitHash()
-    versionSemantic = "0.3.1"
+    versionSemantic = "0.4.0"
 
     bintrayRepo = 'maven'
     bintrayName = 'ControlSDK'

--- a/demo/src/main/java/org/btelman/control/sdk/demo/DemoActivity.kt
+++ b/demo/src/main/java/org/btelman/control/sdk/demo/DemoActivity.kt
@@ -127,6 +127,7 @@ class DemoActivity : AppCompatActivity() {
         arrayList.add(audioComponent)
         arrayList.add(hardwareComponent)
         arrayList.add(dummyComponent)
+        arrayList.add(ComponentHolder(UnstableComponent::class.java, Bundle()))
     }
 
     fun parseColorForOperation(state : Operation?) : Int{

--- a/demo/src/main/java/org/btelman/control/sdk/demo/UnstableComponent.kt
+++ b/demo/src/main/java/org/btelman/control/sdk/demo/UnstableComponent.kt
@@ -1,0 +1,21 @@
+package org.btelman.control.sdk.demo
+
+import org.btelman.controlsdk.enums.ComponentType
+import org.btelman.controlsdk.models.Component
+
+/**
+ * Example of the ControlSDK handling unstable components
+ */
+class UnstableComponent : Component() {
+    override fun enableInternal() {
+        throw Exception("enableInternal Throwing Exception!!!")
+    }
+
+    override fun disableInternal() {
+        throw Exception("disableInternal Throwing Exception!!!")
+    }
+
+    override fun getType(): ComponentType {
+        return ComponentType.CUSTOM
+    }
+}

--- a/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
@@ -269,6 +269,7 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
     }
 
     companion object {
+        var allowNotificationForExceptions = true
         const val START = 1
         const val STOP = 2
         const val RESET = 4

--- a/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
@@ -258,6 +258,7 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
      */
     private fun setupForeground() {
         val intentHide = Intent(SERVICE_STOP_BROADCAST)
+        intentHide.setPackage(packageName)
         val hide = PendingIntent.getBroadcast(this,
                 System.currentTimeMillis().toInt(), intentHide, PendingIntent.FLAG_CANCEL_CURRENT)
         val notification = NotificationCompat.Builder(this, CONTROL_SERVICE)

--- a/sdk/core/src/main/res/values/strings.xml
+++ b/sdk/core/src/main/res/values/strings.xml
@@ -10,4 +10,7 @@
     <string name="send_data_permissions_details">Allow app to send data to ControlSDK</string>
     <string name="appBackgrounded">App is running in the background.</string>
     <string name="terminateApp">Terminate app</string>
+    <string name="componentCrashed">Error detected</string>
+    <string name="componentCrashedText">component stopped working</string>
+    <string name="error">Error</string>
 </resources>

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -52,7 +52,9 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
 
     override fun setupCamera(streamInfo : StreamInfo?){ //TODO actually use resolution from here?
         camera ?: run {
-            val cameraId = streamInfo?.deviceInfo?.getCameraId()?.takeIf { Camera.getNumberOfCameras() > it } ?: 0
+            val cameraId = streamInfo?.deviceInfo?.getCameraId() ?: 0
+            if(cameraId > Camera.getNumberOfCameras())
+                throw Exception("Attempted to open camera $cameraId. Only ${Camera.getNumberOfCameras()} devices exist!")
             camera = Camera.open(cameraId)
             camera?.setDisplayOrientation(90)
         }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -54,7 +54,7 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
         camera ?: run {
             val cameraId = streamInfo?.deviceInfo?.getCameraId() ?: 0
             if(cameraId > Camera.getNumberOfCameras())
-                throw Exception("Attempted to open camera $cameraId. Only ${Camera.getNumberOfCameras()} devices exist!")
+                throw Exception("Attempted to open camera $cameraId. Only ${Camera.getNumberOfCameras()} cameras exist!")
             camera = Camera.open(cameraId)
             camera?.setDisplayOrientation(90)
         }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -52,7 +52,7 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
 
     override fun setupCamera(streamInfo : StreamInfo?){ //TODO actually use resolution from here?
         camera ?: run {
-            val cameraId = streamInfo?.deviceInfo?.getCameraId()?:0
+            val cameraId = streamInfo?.deviceInfo?.getCameraId()?.takeIf { Camera.getNumberOfCameras() > it } ?: 0
             camera = Camera.open(cameraId)
             camera?.setDisplayOrientation(90)
         }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2SurfaceTextureComponent.kt
@@ -71,8 +71,10 @@ class Camera2SurfaceTextureComponent : SurfaceTextureVideoRetriever(), ImageRead
         try {
             val list = manager.cameraIdList
             val requestedId = streamInfo?.deviceInfo?.getCameraId()?:0
-            val cameraId = if(requestedId < list.size) requestedId else 0
-            manager.openCamera(list[cameraId], mStateCallback, null)
+            if(requestedId > list.size){
+                throw java.lang.Exception("Attempted to open camera $requestedId. Only ${list.size} cameras exist!")
+            }
+            manager.openCamera(list[requestedId], mStateCallback, null)
         } catch (e: CameraAccessException) {
             e.printStackTrace()
             //TODO throw error and kill service?


### PR DESCRIPTION
Breaking change: Trying to use invalid camera will no longer fall back to working one.
Fixes: App no longer crashes when selecting invalid camera on API19 and below

Surrounds enable() and disable() functions of components with an exception catcher and allows for the error to pop up in notifications when it happens with a general description. This does log the entire error and stacktrace in logcat

Added field access to turn off notification if needed
ControlSDKService.allowNotificationForExceptions = false

Also fixed https://github.com/btelman96/ControlSDK/issues/15