### PR TITLE
Fix camera performance issues and bugs

### DIFF
--- a/sdk/core/src/main/java/org/btelman/controlsdk/utils/BundleUtil.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/utils/BundleUtil.kt
@@ -5,16 +5,16 @@ import android.os.Bundle
 /**
  * Util for bundles
  */
-fun <T> Class<T>.toBundle(key : String) : Bundle {
-    return intoBundle(key, Bundle())
-}
-
-fun <T> Class<T>.intoBundle(key : String, bundle: Bundle) : Bundle {
-    bundle.putSerializable(key, this::class.java)
-    return bundle
-}
-
 object BundleUtil{
+    fun toBundle(key : String, clazz : Class<*>) : Bundle {
+        return intoBundle(key, clazz, Bundle())
+    }
+
+    fun intoBundle(key : String, clazz : Class<*>, bundle: Bundle) : Bundle {
+        bundle.putSerializable(key, clazz)
+        return bundle
+    }
+
     fun <T> checkForAndInitClass(clazz : Class<*>?, base : Class<T>) : T?{
         return if(checkIfClassMatches(clazz, base))
             clazz!!.newInstance() as T

--- a/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/AudioProcessorFactoryAndroidTest.kt
+++ b/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/AudioProcessorFactoryAndroidTest.kt
@@ -4,6 +4,7 @@ import androidx.test.runner.AndroidJUnit4
 import org.btelman.controlsdk.streaming.audio.processors.BaseAudioProcessor
 import org.btelman.controlsdk.streaming.audio.processors.FFmpegAudioProcessor
 import org.btelman.controlsdk.streaming.factories.AudioProcessorFactory
+import org.btelman.controlsdk.streaming.models.AudioPacket
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.junit.Assert
 import org.junit.Test
@@ -37,8 +38,8 @@ class AudioProcessorFactoryAndroidTest {
     }
 
     class MockAudioProcessor : BaseAudioProcessor() {
-        override fun processAudioByteArray(data: ByteArray) {
-            TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+        override fun processAudioByteArray(data: AudioPacket) {
+
         }
     }
 }

--- a/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/AudioRetrieverFactoryAndroidTest.kt
+++ b/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/AudioRetrieverFactoryAndroidTest.kt
@@ -4,6 +4,7 @@ import androidx.test.runner.AndroidJUnit4
 import org.btelman.controlsdk.streaming.audio.retrievers.BaseAudioRetriever
 import org.btelman.controlsdk.streaming.audio.retrievers.BasicMicrophoneAudioRetriever
 import org.btelman.controlsdk.streaming.factories.AudioRetrieverFactory
+import org.btelman.controlsdk.streaming.models.AudioPacket
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.junit.Assert
 import org.junit.Test
@@ -40,7 +41,7 @@ class AudioRetrieverFactoryAndroidTest {
     }
 
     class MockAudioRetriever : BaseAudioRetriever() {
-        override fun retrieveAudioByteArray(): ByteArray? {
+        override fun retrieveAudioByteArray(): AudioPacket? {
             TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
         }
     }

--- a/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/StreamingTestSuite.kt
+++ b/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/StreamingTestSuite.kt
@@ -1,0 +1,16 @@
+package org.btelman.controlsdk.streaming
+
+/**
+ * Created by Brendon on 8/31/2019.
+ */
+import org.junit.runner.RunWith
+import org.junit.runners.Suite
+
+// Runs all unit tests.
+@RunWith(Suite::class)
+@Suite.SuiteClasses(
+    AudioProcessorFactoryAndroidTest::class,
+    AudioRetrieverFactoryAndroidTest::class,
+    VideoProcessorFactoryAndroidTest::class,
+    VideoRetrieverFactoryAndroidTest::class)
+class UnitTestSuite

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
@@ -43,8 +43,10 @@ abstract class StreamComponent<R : StreamSubComponent,P : StreamSubComponent> : 
     }
 
     fun fetchFrame() {
+        handler.postDelayed({
+            push(DO_FRAME)
+        },1000/30)
         doWorkLoop()
-        push(DO_FRAME)
     }
 
     abstract fun doWorkLoop()

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
@@ -43,9 +43,7 @@ abstract class StreamComponent<R : StreamSubComponent,P : StreamSubComponent> : 
     }
 
     fun fetchFrame() {
-        handler.postDelayed({
-            push(DO_FRAME)
-        },1000/30)
+        push(DO_FRAME)
         doWorkLoop()
     }
 

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/VideoComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/VideoComponent.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import org.btelman.controlsdk.streaming.factories.VideoProcessorFactory
 import org.btelman.controlsdk.streaming.factories.VideoRetrieverFactory
+import org.btelman.controlsdk.streaming.models.ImageDataPacket
 import org.btelman.controlsdk.streaming.video.processors.BaseVideoProcessor
 import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
 
@@ -13,21 +14,64 @@ import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
  * Other classes will extend this for connectivity with specific integrations
  */
 open class VideoComponent : StreamComponent<BaseVideoRetriever, BaseVideoProcessor>()  {
+    private var sendStaleFramesWhenStarved = false
+    private var sendStaleFramesDelay = 0
+    private var targetFPS = 30
+    private var lastTimeCode = 0L
 
     override fun onInitializeComponent(applicationContext: Context, bundle: Bundle?) {
         super.onInitializeComponent(applicationContext, bundle)
         bundle!!
         processor = VideoProcessorFactory.findProcessor(bundle) ?: throw IllegalArgumentException("unable to resolve video processor")
         retriever = VideoRetrieverFactory.findRetriever(bundle) ?: throw IllegalArgumentException("unable to resolve video retriever")
+        targetFPS = bundle.getInt(VIDEO_FRAMERATE_LOOP, 30)
+        sendStaleFramesWhenStarved = bundle.getBoolean(VIDEO_SEND_STALE_FRAMES_WHEN_STARVED, false)
+        if(sendStaleFramesWhenStarved)
+            sendStaleFramesDelay = bundle.getInt(VIDEO_STALE_FRAME_DELAY, 1000)
     }
-
-    var lastTimecode = 0L
 
     override fun doWorkLoop() {
         retriever.grabImageData()?.let {
-            if(lastTimecode == it.timecode) return
-            lastTimecode = it.timecode
+            //Don't send more than one frame twice
+            //Don't allow data to update more than desired frames per second
+            if(!shouldProcessData(it, lastTimeCode)) return
+            lastTimeCode = it.timecode
             processor.processData(it)
         }
+    }
+
+    private fun shouldProcessData(packet : ImageDataPacket, lastTimeCode : Long) : Boolean{
+        val timeCodeDiff = System.currentTimeMillis()-lastTimeCode
+        if (lastTimeCode == packet.timecode) {
+            /*only time this evaluates to true is when starved for more than delay.
+                Once it reaches this point, the check will always succeed until a new frame is retrieved.
+                It will still be limited by the framerate check*/
+            return sendStaleFramesWhenStarved
+                    && timeCodeDiff > sendStaleFramesDelay
+        }
+        if (timeCodeDiff < 1000/targetFPS) return false
+        return true
+    }
+
+    companion object{
+        /**
+         * How fast the class will try to process frames as Integer
+         *
+         * DEFAULT: 30
+         */
+        const val VIDEO_FRAMERATE_LOOP = "VideoComponent.FrameRate"
+        /**
+         * Whether or not stale frames are allowed to send at all as Boolean
+         *
+         * DEFAULT: false
+         */
+        const val VIDEO_SEND_STALE_FRAMES_WHEN_STARVED = "VideoComponent.SendStaleFrames"
+        /**
+         * Delay that is needed before stale frames will start being processed.
+         * Stale frames do not normally get processed right away
+         *
+         * DEFAULT: 1000 milliseconds
+         */
+        const val VIDEO_STALE_FRAME_DELAY = "VideoComponent.FreshToStaleDelay"
     }
 }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/VideoComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/VideoComponent.kt
@@ -21,8 +21,12 @@ open class VideoComponent : StreamComponent<BaseVideoRetriever, BaseVideoProcess
         retriever = VideoRetrieverFactory.findRetriever(bundle) ?: throw IllegalArgumentException("unable to resolve video retriever")
     }
 
+    var lastTimecode = 0L
+
     override fun doWorkLoop() {
         retriever.grabImageData()?.let {
+            if(lastTimecode == it.timecode) return
+            lastTimecode = it.timecode
             processor.processData(it)
         }
     }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/AudioProcessorFactory.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/AudioProcessorFactory.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import org.btelman.controlsdk.streaming.audio.processors.BaseAudioProcessor
 import org.btelman.controlsdk.streaming.audio.processors.FFmpegAudioProcessor
 import org.btelman.controlsdk.utils.BundleUtil
-import org.btelman.controlsdk.utils.intoBundle
 
 /**
  * Handles creating the BaseVideoProcessor instance or putting the class in the main bundle
@@ -18,7 +17,7 @@ object AudioProcessorFactory {
     }
 
     fun <T : BaseAudioProcessor> putClassInBundle(clazz: Class<T>, bundle: Bundle){
-        clazz.intoBundle(BUNDLE_ID, bundle)
+        BundleUtil.intoBundle(BUNDLE_ID, clazz, bundle)
     }
 
     fun getClassFromBundle(bundle: Bundle) : Class<*>?{

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/AudioRetrieverFactory.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/AudioRetrieverFactory.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import org.btelman.controlsdk.streaming.audio.retrievers.BaseAudioRetriever
 import org.btelman.controlsdk.streaming.audio.retrievers.BasicMicrophoneAudioRetriever
 import org.btelman.controlsdk.utils.BundleUtil
-import org.btelman.controlsdk.utils.intoBundle
 
 /**
  * Handles creating the BaseVideoProcessor instance or putting the class in the main bundle
@@ -18,7 +17,7 @@ object AudioRetrieverFactory {
     }
 
     fun <T : BaseAudioRetriever> putClassInBundle(clazz: Class<T>, bundle: Bundle){
-        clazz.intoBundle(AudioProcessorFactory.BUNDLE_ID, bundle)
+        BundleUtil.intoBundle(BUNDLE_ID, clazz, bundle)
     }
 
     fun getClassFromBundle(bundle: Bundle) : Class<*>?{

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoProcessorFactory.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoProcessorFactory.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import org.btelman.controlsdk.streaming.video.processors.BaseVideoProcessor
 import org.btelman.controlsdk.streaming.video.processors.FFmpegVideoProcessor
 import org.btelman.controlsdk.utils.BundleUtil
-import org.btelman.controlsdk.utils.intoBundle
 
 /**
  * Handles creating the BaseVideoProcessor instance or putting the class in the main bundle
@@ -18,7 +17,7 @@ object VideoProcessorFactory {
     }
 
     fun <T : BaseVideoProcessor> putClassInBundle(clazz: Class<T>, bundle: Bundle){
-        clazz.intoBundle(AudioProcessorFactory.BUNDLE_ID, bundle)
+        BundleUtil.intoBundle(BUNDLE_ID, clazz, bundle)
     }
 
     fun getClassFromBundle(bundle: Bundle) : Class<*>?{

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoRetrieverFactory.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoRetrieverFactory.kt
@@ -1,11 +1,9 @@
 package org.btelman.controlsdk.streaming.factories
 
-import android.os.Build
 import android.os.Bundle
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
-import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
-import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTextureComponent
+import org.btelman.controlsdk.streaming.video.retrievers.CameraCompatRetriever
 import org.btelman.controlsdk.utils.BundleUtil
 
 object VideoRetrieverFactory {
@@ -15,13 +13,12 @@ object VideoRetrieverFactory {
         }
         StreamInfo.fromBundle(bundle)?.also {streamInfo ->
             when {
-                streamInfo.deviceInfo.camera.contains("/dev/video") -> TODO("USB Camera retriever class")
-                streamInfo.deviceInfo.camera.contains("/dev/camera") -> return if(Build.VERSION.SDK_INT >= 21){
-                    Camera2SurfaceTextureComponent()
-                } else{
-                    Camera1SurfaceTextureComponent()
-                }
-                streamInfo.deviceInfo.camera.contains("http") -> TODO("Camera stream from other device")
+                streamInfo.deviceInfo.camera.contains("/dev/video") ->
+                    TODO("USB Camera retriever class")
+                streamInfo.deviceInfo.camera.contains("/dev/camera") ->
+                    return CameraCompatRetriever()
+                streamInfo.deviceInfo.camera.contains("http") ->
+                    TODO("Camera stream from other device")
             }
         }
         return DEFAULT.newInstance()
@@ -35,6 +32,6 @@ object VideoRetrieverFactory {
         return BundleUtil.getClassFromBundle(bundle, BUNDLE_ID)
     }
 
-    val DEFAULT = Camera1SurfaceTextureComponent::class.java
+    val DEFAULT = CameraCompatRetriever::class.java
     const val BUNDLE_ID = "videoRetrieverClass"
 }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoRetrieverFactory.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoRetrieverFactory.kt
@@ -7,7 +7,6 @@ import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
 import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
 import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTextureComponent
 import org.btelman.controlsdk.utils.BundleUtil
-import org.btelman.controlsdk.utils.intoBundle
 
 object VideoRetrieverFactory {
     fun findRetriever(bundle: Bundle): BaseVideoRetriever? {
@@ -29,7 +28,7 @@ object VideoRetrieverFactory {
     }
 
     fun <T : BaseVideoRetriever> putClassInBundle(clazz: Class<T>, bundle: Bundle){
-        clazz.intoBundle(BUNDLE_ID, bundle)
+        BundleUtil.intoBundle(BUNDLE_ID, clazz, bundle)
     }
 
     fun getClassFromBundle(bundle: Bundle) : Class<*>?{

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoRetrieverFactory.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/factories/VideoRetrieverFactory.kt
@@ -29,7 +29,7 @@ object VideoRetrieverFactory {
     }
 
     fun <T : BaseVideoRetriever> putClassInBundle(clazz: Class<T>, bundle: Bundle){
-        clazz.intoBundle(AudioProcessorFactory.BUNDLE_ID, bundle)
+        clazz.intoBundle(BUNDLE_ID, bundle)
     }
 
     fun getClassFromBundle(bundle: Bundle) : Class<*>?{

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
@@ -1,0 +1,64 @@
+package org.btelman.controlsdk.streaming.video.retrievers
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.os.Build
+import android.util.Log
+import org.btelman.controlsdk.streaming.models.ImageDataPacket
+import org.btelman.controlsdk.streaming.models.StreamInfo
+import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
+import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTextureComponent
+
+/**
+ * Handle compatibility between camera1 and camera2 usage, since some api21 devices are
+ * not compatible, which makes frame grabbing really slow. Usage of Camera1 or Camera2 classes are
+ * still supported, but may not work on every device
+ * ex. Samsung Galaxy S4
+ */
+class CameraCompatRetriever : BaseVideoRetriever(){
+    private var retriever : BaseVideoRetriever? = null
+
+    override fun grabImageData(): ImageDataPacket? {
+        return retriever?.grabImageData()
+    }
+
+    override fun enable(context: Context, streamInfo: StreamInfo) {
+        super.enable(context, streamInfo)
+        val cameraInfo = streamInfo.deviceInfo
+        val cameraId = cameraInfo.getCameraId()
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+            && validateCamera2Support(context, cameraId)){
+            Log.d("CameraRetriever", "Using Camera2 API")
+            retriever = Camera2SurfaceTextureComponent()
+        }
+        else{
+            Log.d("CameraRetriever",
+                "Using Camera1 API. Device API too low or LIMITED capabilities")
+            retriever = Camera1SurfaceTextureComponent()
+        }
+        retriever?.enable(context, streamInfo)
+    }
+
+    override fun disable() {
+        super.disable()
+        retriever?.disable()
+        retriever = null
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun validateCamera2Support(context: Context, cameraId: Int): Boolean {
+        try {
+            val cm = (context.getSystemService(Context.CAMERA_SERVICE) as CameraManager)
+            val hardwareLevel = cm.getCameraCharacteristics(
+                cm.cameraIdList[cameraId]
+            )[CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL]
+            return hardwareLevel != CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY
+                    && hardwareLevel != CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LIMITED
+        } catch (_: Exception) {
+
+        }
+        return false
+    }
+}

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -7,7 +7,6 @@ import org.btelman.controlsdk.streaming.models.ImageDataPacket
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.SurfaceTextureVideoRetriever
 
-
 /**
  * Class that contains only the camera components for streaming to letsrobot.tv
  *
@@ -51,8 +50,8 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
     }
 
     override fun setupCamera(streamInfo : StreamInfo?){ //TODO actually use resolution from here?
+        val cameraId = streamInfo?.deviceInfo?.getCameraId() ?: 0
         camera ?: run {
-            val cameraId = streamInfo?.deviceInfo?.getCameraId() ?: 0
             if(cameraId+1 > Camera.getNumberOfCameras())
                 throw Exception("Attempted to open camera $cameraId. Only ${Camera.getNumberOfCameras()} cameras exist! 0 is first camera")
             camera = Camera.open(cameraId)
@@ -61,6 +60,8 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
         camera?.let {
             val p = it.parameters
             p.setPreviewSize(640, 480)
+            p.setPictureSize(640, 480)
+            p.setRecordingHint(true)
             it.parameters = p
             it.setPreviewTexture(mStManager?.surfaceTexture)
             it.setPreviewCallback(this)


### PR DESCRIPTION
- [x] Fix factory class bundle bug that prevents custom classes from being used

- [ ] ~~Fix performance of Camera2 on Galaxy S4~~ Falls back to Camera1 now since S4 was LEGACY

- [x] Don't process the same frame multiple times

- [x] Rate limit video processing at 30fps

- [x] Add compat class that picks camera1 vs camera2 based on hardware capability. This means some 5.0 or above devices could be restricted to only camera1