### PR TITLE
Audio Processor no longer crashes the app if the inputStream was closed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext{
     globalBuildToolsVersion = "28.0.3"
     buildNumber = BITRISE_BUILD_NUMBER
     gitHash = getGitHash()
-    versionSemantic = "0.8.1"
+    versionSemantic = "0.8.2"
 
     bintrayRepo = 'maven'
     bintrayName = 'ControlSDK'

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/processors/FFmpegAudioProcessor.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/processors/FFmpegAudioProcessor.kt
@@ -58,14 +58,19 @@ open class FFmpegAudioProcessor : BaseAudioProcessor(), FFmpegExecuteResponseHan
 
     override fun processAudioByteArray(data: AudioPacket) {
         if(!streaming.get()) return
-        if (!ffmpegRunning.getAndSet(true)) {
-            tryBootFFmpeg()
-        }
-        process?.let { _process ->
-            if(data.timecode != lastTimecode){ //make sure we only send each packet once
-                lastTimecode = data.timecode
-                OutputStreamUtil.handleSendByteArray(_process.outputStream, data.b)
+        try {
+            if (!ffmpegRunning.getAndSet(true)) {
+                tryBootFFmpeg()
             }
+            process?.let { _process ->
+                if(data.timecode != lastTimecode){ //make sure we only send each packet once
+                    lastTimecode = data.timecode
+                    OutputStreamUtil.handleSendByteArray(_process.outputStream, data.b)
+                }
+            }
+        } catch (e: Exception) {
+            status = ComponentStatus.ERROR
+            e.printStackTrace()
         }
     }
 


### PR DESCRIPTION
Was due to network issues, especially when losing connection to a hotspot and transitioning to other WiFi