### PR TITLE
Release 0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext{
     globalBuildToolsVersion = "28.0.3"
     buildNumber = BITRISE_BUILD_NUMBER
     gitHash = getGitHash()
-    versionSemantic = "0.8.2"
+    versionSemantic = "0.9.0"
 
     bintrayRepo = 'maven'
     bintrayName = 'ControlSDK'

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
@@ -15,6 +15,7 @@ abstract class StreamComponent<R : StreamSubComponent,P : StreamSubComponent> : 
     protected lateinit var streamInfo : StreamInfo
     protected lateinit var processor : P
     protected lateinit var retriever : R
+    protected var shouldAutoUpdateLoop = true
 
     override fun onInitializeComponent(applicationContext: Context, bundle: Bundle?) {
         super.onInitializeComponent(applicationContext, bundle)
@@ -43,7 +44,7 @@ abstract class StreamComponent<R : StreamSubComponent,P : StreamSubComponent> : 
     }
 
     fun fetchFrame() {
-        push(DO_FRAME)
+        if(shouldAutoUpdateLoop) push(DO_FRAME)
         doWorkLoop()
     }
 
@@ -67,8 +68,8 @@ abstract class StreamComponent<R : StreamSubComponent,P : StreamSubComponent> : 
     }
 
     companion object{
-        private const val FRAME_FETCH = 0
-        private const val FRAME_PUSH = 1
-        private const val DO_FRAME = 2
+        const val FRAME_FETCH = 0
+        const val FRAME_PUSH = 1
+        const val DO_FRAME = 2
     }
 }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/BaseVideoRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/BaseVideoRetriever.kt
@@ -8,4 +8,18 @@ import org.btelman.controlsdk.streaming.models.ImageDataPacket
  */
 abstract class BaseVideoRetriever : StreamSubComponent(){
     abstract fun grabImageData() : ImageDataPacket?
+
+    protected var frameListener : (()->Unit)? = null
+
+    open fun notifyFrameUpdated(){
+        frameListener?.invoke()
+    }
+
+    open fun listenForFrame(func : ()->Unit){
+        frameListener = func
+    }
+
+    open fun removeListenerForFrame(){
+        frameListener = null
+    }
 }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
@@ -41,6 +41,14 @@ class CameraCompatRetriever : BaseVideoRetriever(){
         retriever?.enable(context, streamInfo)
     }
 
+    override fun listenForFrame(func: () -> Unit) {
+        retriever?.listenForFrame(func)
+    }
+
+    override fun removeListenerForFrame() {
+        retriever?.removeListenerForFrame()
+    }
+
     override fun disable() {
         super.disable()
         retriever?.disable()

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/SurfaceTextureVideoRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/SurfaceTextureVideoRetriever.kt
@@ -24,6 +24,7 @@ abstract class SurfaceTextureVideoRetriever : BaseVideoRetriever() {
 
     override fun enable(context: Context, streamInfo: StreamInfo) {
         super.enable(context, streamInfo)
+
         eglSurface = eglCore?.createOffscreenSurface(streamInfo.width, streamInfo.height)
         eglCore?.makeCurrent(eglSurface)
         mStManager = SurfaceTextureUtils.SurfaceTextureManager()

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -39,6 +39,7 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
                 r = Rect(0, 0, _widthV1, _heightV1)
             }
         }
+        notifyFrameUpdated()
         latestPackage = ImageDataPacket(b, ImageFormat.NV21, r)
     }
 

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2SurfaceTextureComponent.kt
@@ -121,6 +121,7 @@ class Camera2SurfaceTextureComponent : SurfaceTextureVideoRetriever(), ImageRead
             image = reader?.acquireLatestImage()
             image?.let {
                 latestPackage = ImageDataPacket(convertYuv420888ToYuv(image), ImageFormat.YUV_420_888)
+                notifyFrameUpdated()
             }
         } finally {
             image?.close()

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2SurfaceTextureComponent.kt
@@ -50,11 +50,13 @@ class Camera2SurfaceTextureComponent : SurfaceTextureVideoRetriever(), ImageRead
         }
 
         override fun onDisconnected(@NonNull cameraDevice: CameraDevice) {
+            closePreviewSession()
             cameraDevice.close()
             mCameraDevice = null
         }
 
         override fun onError(@NonNull cameraDevice: CameraDevice, error: Int) {
+            closePreviewSession()
             cameraDevice.close()
             mCameraDevice = null
         }
@@ -92,6 +94,8 @@ class Camera2SurfaceTextureComponent : SurfaceTextureVideoRetriever(), ImageRead
     override fun releaseCamera() {
         stopBackgroundThread()
         reader?.close()
+        closePreviewSession()
+        mCameraDevice?.close()
     }
 
     private var latestPackage : ImageDataPacket? = null


### PR DESCRIPTION
- Close Camera2 properly
- add performance saving option that does not try grabbing the frame unless an event was hit