### PR TITLE
Status update changes to allow subcomponents of streaming and hardware to broadcast statuses

### DIFF
--- a/demo/src/main/java/org/btelman/control/sdk/demo/DemoActivity.kt
+++ b/demo/src/main/java/org/btelman/control/sdk/demo/DemoActivity.kt
@@ -29,6 +29,9 @@ import org.btelman.controlsdk.streaming.models.CameraDeviceInfo
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
 import org.btelman.controlsdk.tts.SystemDefaultTTSComponent
+import org.btelman.logutil.kotlin.LogLevel
+import org.btelman.logutil.kotlin.LogUtil
+import org.btelman.logutil.kotlin.LogUtilInstance
 
 class DemoActivity : AppCompatActivity() {
 
@@ -39,7 +42,10 @@ class DemoActivity : AppCompatActivity() {
     val bt = BluetoothClassicDriver()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        LogUtilInstance(ControlSDKService.CONTROL_SERVICE, LogLevel.VERBOSE).also {
+            Log.d("DemoActivity", "Setup logger")
+            LogUtil.addCustomLogUtilInstance(ControlSDKService::class.java.name, it)
+        }
         if(!FFmpegRunner.checkIfUpToDate(this))
             FFmpegRunner.update(this)
         //examples of fetching all available services

--- a/sdk/core/build.gradle
+++ b/sdk/core/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     def coroutines_version = "1.2.1"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+    api 'org.btelman.logutil:logutil:1.0'
     implementation 'androidx.appcompat:appcompat:1.1.0' //annotations...
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     api 'com.google.guava:guava:27.1-android'

--- a/sdk/core/src/androidTest/java/org/btelman/controlsdk/IsolatedComponentTest.kt
+++ b/sdk/core/src/androidTest/java/org/btelman/controlsdk/IsolatedComponentTest.kt
@@ -2,7 +2,7 @@ package org.btelman.controlsdk
 
 import androidx.test.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
-import org.btelman.controlsdk.services.ControlSDKService
+import org.btelman.controlsdk.models.Component
 import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -19,7 +19,7 @@ class IsolatedComponentTest {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getTargetContext()
         val holder = DummyComponent.Companion.Builder("foo", 123).build()
-        val component = ControlSDKService.instantiateComponent(appContext, holder) as DummyComponent
+        val component = Component.instantiate(appContext, holder) as DummyComponent
         Assert.assertEquals("foo", component.bundle?.getString(DummyComponent.ARG1_KEY))
         Assert.assertEquals(123, component.bundle?.getInt(DummyComponent.ARG2_KEY))
     }

--- a/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
@@ -103,6 +103,21 @@ abstract class Component : IComponent {
         return@async true
     }
 
+    /**
+     * Called when component should shut down
+     *
+     * Will return without action if already enabled
+     */
+    override fun disable() = GlobalScope.async{
+        if(!enabled.getAndSet(false)) return@async false
+        log.d{
+            "disable"
+        }
+        awaitCallback<Boolean> { disableWithCallback(it) }
+        status = ComponentStatus.DISABLED
+        return@async true
+    }
+
     fun enableWithCallback(callback: Callback<Boolean>){
         handler.post {
             try {
@@ -145,21 +160,6 @@ abstract class Component : IComponent {
                     }
                 })
             }
-
-    /**
-     * Called when component should shut down
-     *
-     * Will return without action if already enabled
-     */
-    override fun disable() = GlobalScope.async{
-        if(!enabled.getAndSet(false)) return@async false
-        log.d{
-            "disable"
-        }
-        awaitCallback<Boolean> { disableWithCallback(it) }
-        status = ComponentStatus.DISABLED
-        return@async true
-    }
 
     /**
      * Called when we have not received a response from the server in a while

--- a/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
@@ -35,7 +35,7 @@ abstract class Component : IComponent {
             javaClass.simpleName
     ).also { it.start() }
 
-    protected val log = LogUtil("ControlSDKComponent : ${getName()}", ControlSDKService::class.java.name)
+    protected val log = LogUtil("ControlSDKComponent : ${getName()}", ControlSDKService.loggerID)
 
     /**
      * Constructor that the service will use to start the component. For custom actions, please use onInitializeComponent

--- a/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
@@ -68,6 +68,10 @@ abstract class Component : IComponent {
     protected abstract fun enableInternal()
     protected abstract fun disableInternal()
 
+    open fun getInitialStatus() : ComponentStatus{
+        return ComponentStatus.STABLE
+    }
+
     override fun setEventListener(listener: ComponentEventListener?) {
         log.d{
             "setEventListener"
@@ -98,7 +102,7 @@ abstract class Component : IComponent {
             "enable"
         }
         if(enabled.getAndSet(true)) return@async false
-        status = ComponentStatus.CONNECTING
+        status = getInitialStatus()
         awaitCallback<Boolean> { enableWithCallback(it) }
         return@async true
     }

--- a/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/models/Component.kt
@@ -16,6 +16,7 @@ import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.interfaces.ComponentEventListener
 import org.btelman.controlsdk.interfaces.IComponent
 import org.btelman.controlsdk.services.ControlSDKService
+import org.btelman.logutil.kotlin.LogUtil
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -34,6 +35,8 @@ abstract class Component : IComponent {
             javaClass.simpleName
     ).also { it.start() }
 
+    protected val log = LogUtil("ControlSDKComponent : ${getName()}", ControlSDKService::class.java.name)
+
     /**
      * Constructor that the service will use to start the component. For custom actions, please use onInitializeComponent
      */
@@ -50,6 +53,9 @@ abstract class Component : IComponent {
         set(value) {
             if(_status == value) return //Only set state if changed
             _status = value
+            log.v{
+                "Update Status $value : ${eventDispatcher?.let { "Sending upwards" } ?: "dispatcher null"}"
+            }
             eventDispatcher?.handleMessage(getType(),
                 STATUS_EVENT, status, this)
         }
@@ -63,6 +69,9 @@ abstract class Component : IComponent {
     protected abstract fun disableInternal()
 
     override fun setEventListener(listener: ComponentEventListener?) {
+        log.d{
+            "setEventListener"
+        }
         eventDispatcher = listener
     }
 
@@ -72,6 +81,9 @@ abstract class Component : IComponent {
 
 
     protected fun reset() { //TODO this could potentially create thread locks?
+        log.d{
+            "reset"
+        }
         runBlocking {
             disable().await()
             enable().await()
@@ -82,6 +94,9 @@ abstract class Component : IComponent {
      * Called when component should startup. Will return without action if already enabled
      */
     override fun enable() = GlobalScope.async{
+        log.d{
+            "enable"
+        }
         if(enabled.getAndSet(true)) return@async false
         status = ComponentStatus.CONNECTING
         awaitCallback<Boolean> { enableWithCallback(it) }
@@ -138,6 +153,9 @@ abstract class Component : IComponent {
      */
     override fun disable() = GlobalScope.async{
         if(!enabled.getAndSet(false)) return@async false
+        log.d{
+            "disable"
+        }
         awaitCallback<Boolean> { disableWithCallback(it) }
         status = ComponentStatus.DISABLED
         return@async true
@@ -178,6 +196,9 @@ abstract class Component : IComponent {
      * Used to retrieve Context and provide an initialization bundle
      */
     open fun onInitializeComponent(applicationContext: Context, bundle : Bundle?) {
+        log.d{
+            "onInitializeComponent"
+        }
         context = applicationContext
     }
 

--- a/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
@@ -34,7 +34,7 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
     private var running = false
     private val componentList = ArrayList<ComponentHolder<*>>()
     private val activeComponentList = ArrayList<IComponent>()
-    private val log = LogUtil("ControlSDKService", ControlSDKService::class.java.name)
+    private val log = LogUtil("ControlSDKService", loggerID)
 
     /**
      * Target we publish for clients to send messages to MessageHandler.
@@ -365,10 +365,12 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
         const val CONTROL_SERVICE = "control_service"
         const val SERVICE_STATUS_BROADCAST = "org.btelman.controlsdk.ServiceStatus"
         const val SERVICE_STOP_BROADCAST = "org.btelman.controlsdk.request.stop"
-        private val logInstance = LogUtilInstance(CONTROL_SERVICE, LogLevel.ERROR).also {
-            Log.d("ControlSDKService", "Setup logger")
-            if(!LogUtil.customLoggers.containsKey(ControlSDKService::class.java.name))
-                LogUtil.addCustomLogUtilInstance(ControlSDKService::class.java.name, it)
+        val loggerID: String = ControlSDKService::class.java.name.also {
+            LogUtilInstance(CONTROL_SERVICE, LogLevel.ERROR).also {
+                Log.d("ControlSDKService", "Setup logger")
+                if(!LogUtil.customLoggers.containsKey(ControlSDKService::class.java.name))
+                    LogUtil.addCustomLogUtilInstance(ControlSDKService::class.java.name, it)
+            }
         }
     }
 }

--- a/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
+++ b/sdk/core/src/main/java/org/btelman/controlsdk/services/ControlSDKService.kt
@@ -4,11 +4,13 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.*
+import android.util.Log
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
+import org.btelman.controlsdk.BuildConfig
 import org.btelman.controlsdk.R
 import org.btelman.controlsdk.enums.ComponentType
 import org.btelman.controlsdk.interfaces.ComponentEventListener
@@ -18,6 +20,9 @@ import org.btelman.controlsdk.models.ComponentEventObject
 import org.btelman.controlsdk.models.ComponentHolder
 import org.btelman.controlsdk.utils.InlineBroadcastReceiver
 import org.btelman.controlsdk.utils.NotificationUtil
+import org.btelman.logutil.kotlin.LogLevel
+import org.btelman.logutil.kotlin.LogUtil
+import org.btelman.logutil.kotlin.LogUtilInstance
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -29,6 +34,7 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
     private var running = false
     private val componentList = ArrayList<ComponentHolder<*>>()
     private val activeComponentList = ArrayList<IComponent>()
+    private val log = LogUtil("ControlSDKService", ControlSDKService::class.java.name)
 
     /**
      * Target we publish for clients to send messages to MessageHandler.
@@ -41,7 +47,13 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
     private var stopListenerReceiver: InlineBroadcastReceiver? = null
 
     override fun onCreate() {
+        log.d{
+            "ControlSDK ${BuildConfig.VERSION_NAME} starting..."
+        }
         stopListenerReceiver = InlineBroadcastReceiver(SERVICE_STOP_BROADCAST){ _, _ ->
+            log.d {
+                "User requested service stop"
+            }
             stopService()
             System.exit(0)
         }.also {
@@ -60,23 +72,35 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
      * for sending messages to the service.
      */
     override fun onBind(intent: Intent): IBinder? {
-        Toast.makeText(applicationContext, "binding", Toast.LENGTH_SHORT).show()
+        log.d{
+            Toast.makeText(applicationContext, "binding", Toast.LENGTH_SHORT).show()
+            "onBind"
+        }
         emitState()
         return mMessenger.binder
     }
 
     override fun onRebind(intent: Intent?) {
-        Toast.makeText(applicationContext, "rebinding", Toast.LENGTH_SHORT).show()
+        log.d{
+            Toast.makeText(applicationContext, "rebinding", Toast.LENGTH_SHORT).show()
+            "onRebind"
+        }
         emitState()
         super.onRebind(intent)
     }
 
     override fun onUnbind(intent: Intent?): Boolean {
-        Toast.makeText(applicationContext, "unbinding", Toast.LENGTH_SHORT).show()
+        log.d{
+            Toast.makeText(applicationContext, "unbinding", Toast.LENGTH_SHORT).show()
+            "onUnbind"
+        }
         return true
     }
 
     override fun onTaskRemoved(rootIntent: Intent?) {
+        log.d{
+            "onTaskRemoved"
+        }
         stopService()
         super.onTaskRemoved(rootIntent)
     }
@@ -86,21 +110,35 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
      */
     override fun handleMessage(msg: Message) : Boolean{
         when (msg.what) {
-            START ->
+            START -> {
                 enable()
-            STOP ->
+            }
+            STOP -> {
+                log.d{
+                    "handleMessage : STOP"
+                }
                 disable()
+            }
             ATTACH_COMPONENT -> {
+                log.v{
+                    "handleMessage ATTACH_COMPONENT ${(msg.obj as? ComponentHolder<*>)?.javaClass?.name}"
+                }
                 (msg.obj as? ComponentHolder<*>)?.let {
                     addToLifecycle(it)
                 }
             }
             DETACH_COMPONENT -> {
+                log.v{
+                    "handleMessage DETACH_COMPONENT ${(msg.obj as? ComponentHolder<*>)?.javaClass?.name}"
+                }
                 (msg.obj as? ComponentHolder<*>)?.let {
                     removeFromLifecycle(it)
                 }
             }
             RESET -> {
+                log.d{
+                    "handleMessage RESET"
+                }
                 reset()
             }
             EVENT_BROADCAST ->{
@@ -132,9 +170,18 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
             }
         }
 
+        log.v{
+            "handleMessage EVENT_BROADCAST FROM ${obj?.source?.javaClass?.name} : ${obj?.what} : ${obj?.data}"
+        }
+
         activeComponentList.forEach { component ->
             targetFilter?.takeIf { component.getType() != it }
-                ?: component.dispatchMessage(msg)
+                ?: run{
+                    component.dispatchMessage(msg)
+                    log.v{
+                        "handleMessage EVENT_BROADCAST send to ${component.javaClass.name}"
+                    }
+                }
         }
     }
 
@@ -157,12 +204,21 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
      * Instantiate all of the component holders on componentList and populate the cleared activeComponentList
      */
     private fun instantiateComponents() {
+        log.d{
+            "instantiateComponents"
+        }
         activeComponentList.clear()
         componentList.forEach { holder ->
             try {
                 val component = Component.instantiate(applicationContext, holder)
                 activeComponentList.add(component)
+                log.v{
+                    "instantiateComponents ${component.javaClass.name}"
+                }
             }catch (e : Exception){
+                log.e{
+                    "failed to instantiate ${holder.clazz.name}"
+                }
                 e.printStackTrace()
             }
         }
@@ -177,12 +233,18 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
     fun enable(){
         val componentListener : ComponentEventListener = this
         runBlocking {
-            Toast.makeText(applicationContext, "Starting ControlSDK", Toast.LENGTH_SHORT).show()
+            log.d{
+                Toast.makeText(applicationContext, "Starting ControlSDK", Toast.LENGTH_SHORT).show()
+                "enable"
+            }
             instantiateComponents()
             val list = ArrayList<Deferred<Boolean>>()
 
             //enable all of our components
             activeComponentList.forEach{
+                log.v{
+                    "enabling ${it.javaClass.name}"
+                }
                 it.setEventListener(componentListener)
                 val deferred = it.enable()
                 list.add(deferred) //add their deferred result to a list
@@ -190,6 +252,9 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
 
             //now wait for each one to complete
             list.forEach {
+                log.v{
+                    "waiting for ${it.javaClass.name} to complete enabling"
+                }
                 it.await()
             }
             setState(true)
@@ -200,9 +265,15 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
      * Disables components, blocking the service messaging thread until complete
      */
     fun disable(){
-        Toast.makeText(applicationContext, "Stopping ControlSDK", Toast.LENGTH_SHORT).show()
         runBlocking {
+            log.d{
+                Toast.makeText(applicationContext, "Stopping ControlSDK", Toast.LENGTH_SHORT).show()
+                "disable"
+            }
             activeComponentList.forEach{
+                log.v{
+                    "disabling ${it.javaClass.name}"
+                }
                 it.disable().await()
                 it.setEventListener(null)
             }
@@ -268,6 +339,9 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
      * Setup the foreground service notification
      */
     private fun setupForeground() {
+        log.d{
+            "Start foreground service"
+        }
         val intentHide = Intent(SERVICE_STOP_BROADCAST)
         intentHide.setPackage(packageName)
         val hide = PendingIntent.getBroadcast(this,
@@ -291,5 +365,10 @@ class ControlSDKService : Service(), ComponentEventListener, Handler.Callback {
         const val CONTROL_SERVICE = "control_service"
         const val SERVICE_STATUS_BROADCAST = "org.btelman.controlsdk.ServiceStatus"
         const val SERVICE_STOP_BROADCAST = "org.btelman.controlsdk.request.stop"
+        private val logInstance = LogUtilInstance(CONTROL_SERVICE, LogLevel.ERROR).also {
+            Log.d("ControlSDKService", "Setup logger")
+            if(!LogUtil.customLoggers.containsKey(ControlSDKService::class.java.name))
+                LogUtil.addCustomLogUtilInstance(ControlSDKService::class.java.name, it)
+        }
     }
 }

--- a/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/CommunicationDriverComponent.kt
+++ b/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/CommunicationDriverComponent.kt
@@ -31,6 +31,10 @@ class CommunicationDriverComponent : Component() , Runnable{
         uiHandler.post(this)
     }
 
+    override fun getInitialStatus(): ComponentStatus {
+        return ComponentStatus.CONNECTING
+    }
+
     @Synchronized
     override fun enableInternal(){
         hardwareDriver?.enable()

--- a/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/HardwareComponent.kt
+++ b/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/HardwareComponent.kt
@@ -3,6 +3,7 @@ package org.btelman.controlsdk.hardware.components
 import android.content.Context
 import android.os.Bundle
 import kotlinx.coroutines.runBlocking
+import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.enums.ComponentType
 import org.btelman.controlsdk.hardware.interfaces.Translator
 import org.btelman.controlsdk.models.Component
@@ -34,6 +35,7 @@ class HardwareComponent : Component() {
         runBlocking{
             communicationDriverComponent?.enable()?.await()
         }
+        status = ComponentStatus.STABLE
     }
 
     override fun disableInternal() {

--- a/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/HardwareComponent.kt
+++ b/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/HardwareComponent.kt
@@ -27,6 +27,7 @@ class HardwareComponent : Component() {
         } ?: CommunicationDriverComponent()
         translatorComponent ?: return
         communicationDriverComponent?.onInitializeComponent(applicationContext, bundle)
+        communicationDriverComponent?.setEventListener(eventDispatcher)
     }
 
     override fun enableInternal() {

--- a/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/HardwareComponent.kt
+++ b/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/components/HardwareComponent.kt
@@ -3,7 +3,6 @@ package org.btelman.controlsdk.hardware.components
 import android.content.Context
 import android.os.Bundle
 import kotlinx.coroutines.runBlocking
-import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.enums.ComponentType
 import org.btelman.controlsdk.hardware.interfaces.Translator
 import org.btelman.controlsdk.models.Component
@@ -35,7 +34,6 @@ class HardwareComponent : Component() {
         runBlocking{
             communicationDriverComponent?.enable()?.await()
         }
-        status = ComponentStatus.STABLE
     }
 
     override fun disableInternal() {

--- a/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/drivers/BluetoothClassicDriver.kt
+++ b/sdk/hardware/src/main/java/org/btelman/controlsdk/hardware/drivers/BluetoothClassicDriver.kt
@@ -15,6 +15,8 @@ import org.btelman.controlsdk.hardware.interfaces.HardwareDriver
 /**
  * communication class that works with bluetooth classic
  * and takes control data via EventManager.ROBOT_BYTE_ARRAY event
+ *
+ * TODO better error handling
  */
 @DriverComponent(description = "Send data over bluetooth classic (Serial) at 9600 BAUD", requiresSetup = true)
 class BluetoothClassicDriver : HardwareDriver {

--- a/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/VideoRetrieverFactoryAndroidTest.kt
+++ b/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/VideoRetrieverFactoryAndroidTest.kt
@@ -7,7 +7,7 @@ import org.btelman.controlsdk.streaming.models.ImageDataPacket
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
 import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
-import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTextureComponent
+import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2Component
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Test
@@ -27,7 +27,7 @@ class VideoRetrieverFactoryAndroidTest {
         val streamInfo = StreamInfo("http://example.com:3000") //testing default parameters. Should use either Camera1SurfaceTextureComponent or Camera2SurfaceTextureComponent
         val camera = VideoRetrieverFactory.findRetriever(streamInfo.toBundle())
         if(camera !is Camera1SurfaceTextureComponent &&
-            camera !is Camera2SurfaceTextureComponent)
+            camera !is Camera2Component)
             Assert.fail()
 
         //test custom class
@@ -47,11 +47,11 @@ class VideoRetrieverFactoryAndroidTest {
 
     @Test
     fun testAPI21Camera(){
-        Assume.assumeTrue(Camera2SurfaceTextureComponent.isSupported())
+        Assume.assumeTrue(Camera2Component.isSupported())
         val streamInfo = StreamInfo("http://example.com:3000",
             deviceInfo = CameraDeviceInfo.fromCamera(0))
         val camera = VideoRetrieverFactory.findRetriever(streamInfo.toBundle())
-        Assert.assertTrue(camera is Camera2SurfaceTextureComponent)
+        Assert.assertTrue(camera is Camera2Component)
     }
 
     class MockVideoRetriever : BaseVideoRetriever() {

--- a/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/VideoRetrieverFactoryAndroidTest.kt
+++ b/sdk/streaming/src/androidTest/java/org/btelman/controlsdk/streaming/VideoRetrieverFactoryAndroidTest.kt
@@ -6,6 +6,7 @@ import org.btelman.controlsdk.streaming.models.CameraDeviceInfo
 import org.btelman.controlsdk.streaming.models.ImageDataPacket
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
+import org.btelman.controlsdk.streaming.video.retrievers.CameraCompatRetriever
 import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
 import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2Component
 import org.junit.Assert
@@ -22,12 +23,11 @@ import org.junit.runner.RunWith
 class VideoRetrieverFactoryAndroidTest {
     @Test
     fun findRetrieverTest() {
-        Assert.assertTrue(VideoRetrieverFactory.findRetriever(Bundle()) is Camera1SurfaceTextureComponent)
+        Assert.assertTrue(VideoRetrieverFactory.findRetriever(Bundle()) is CameraCompatRetriever)
 
         val streamInfo = StreamInfo("http://example.com:3000") //testing default parameters. Should use either Camera1SurfaceTextureComponent or Camera2SurfaceTextureComponent
         val camera = VideoRetrieverFactory.findRetriever(streamInfo.toBundle())
-        if(camera !is Camera1SurfaceTextureComponent &&
-            camera !is Camera2Component)
+        if(camera !is Camera1SurfaceTextureComponent && camera !is Camera2Component && camera !is CameraCompatRetriever)
             Assert.fail()
 
         //test custom class
@@ -51,7 +51,7 @@ class VideoRetrieverFactoryAndroidTest {
         val streamInfo = StreamInfo("http://example.com:3000",
             deviceInfo = CameraDeviceInfo.fromCamera(0))
         val camera = VideoRetrieverFactory.findRetriever(streamInfo.toBundle())
-        Assert.assertTrue(camera is Camera2Component)
+        Assert.assertTrue(camera is CameraCompatRetriever)
     }
 
     class MockVideoRetriever : BaseVideoRetriever() {

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/Streaming.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/Streaming.kt
@@ -1,7 +1,0 @@
-package org.btelman.controlsdk.streaming
-
-/**
- * Created by Brendon on 7/10/2019.
- */
-class Streaming {
-}

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/processors/FFmpegAudioProcessor.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/processors/FFmpegAudioProcessor.kt
@@ -1,6 +1,7 @@
 package org.btelman.controlsdk.streaming.audio.processors
 
 import android.content.Context
+import android.os.Bundle
 import android.util.Log
 import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.streaming.models.AudioPacket
@@ -14,11 +15,8 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Process audio from a source and send it to a specified endpoint with FFmpeg
  */
 open class FFmpegAudioProcessor : BaseAudioProcessor() {
-
-    private var streamInfo: StreamInfo? = null
     private var lastTimecode: Long = 0L
     private var endpoint: String? = null
-    private var status: ComponentStatus = ComponentStatus.DISABLED
     private val streaming = AtomicBoolean(false)
     private var ffmpegRunning = AtomicBoolean(false)
 
@@ -26,11 +24,14 @@ open class FFmpegAudioProcessor : BaseAudioProcessor() {
 
     private var successCounter: Int = 0
 
-    override fun enable(context: Context, streamInfo: StreamInfo) {
-        super.enable(context, streamInfo)
-        this.streamInfo = streamInfo
-        endpoint = streamInfo.audioEndpoint ?: return//?: else we can't do anything
-        FFmpegUtil.initFFmpeg(context){ success ->
+    override fun onInitializeComponent(applicationContext: Context, bundle: Bundle?) {
+        super.onInitializeComponent(applicationContext, bundle)
+        endpoint = streamInfo?.audioEndpoint ?: return//?: else we can't do anything
+    }
+
+    override fun enableInternal() {
+        super.enableInternal()
+        FFmpegUtil.initFFmpeg(context!!){ success ->
             streaming.set(success)
             if(!success){
                 throw ExceptionInInitializerError("Unable to stream : FFMpeg Not Supported on this device")
@@ -38,8 +39,8 @@ open class FFmpegAudioProcessor : BaseAudioProcessor() {
         }
     }
 
-    override fun disable() {
-        super.disable()
+    override fun disableInternal() {
+        super.disableInternal()
         process?.destroy()
         process = null
         streaming.set(false)

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/retrievers/BasicMicrophoneAudioRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/retrievers/BasicMicrophoneAudioRetriever.kt
@@ -1,5 +1,6 @@
 package org.btelman.controlsdk.streaming.audio.retrievers
 
+import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.streaming.models.AudioPacket
 import org.btelman.controlsdk.streaming.utils.AudioRecordingThread
 import org.btelman.controlsdk.streaming.utils.AudioUtil
@@ -24,6 +25,8 @@ open class BasicMicrophoneAudioRetriever : BaseAudioRetriever(), AudioRecordingT
     }
 
     override fun onAudioDataReceived(data: ShortArray?) {
+        if(status != ComponentStatus.STABLE)
+            status = ComponentStatus.STABLE
         dataArray = data?.let { audioArr ->
             AudioPacket(AudioUtil.ShortToByte_ByteBuffer_Method(audioArr))
         } //?: null

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/retrievers/BasicMicrophoneAudioRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/audio/retrievers/BasicMicrophoneAudioRetriever.kt
@@ -1,8 +1,6 @@
 package org.btelman.controlsdk.streaming.audio.retrievers
 
-import android.content.Context
 import org.btelman.controlsdk.streaming.models.AudioPacket
-import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.utils.AudioRecordingThread
 import org.btelman.controlsdk.streaming.utils.AudioUtil
 
@@ -15,13 +13,13 @@ open class BasicMicrophoneAudioRetriever : BaseAudioRetriever(), AudioRecordingT
 
     private var dataArray : AudioPacket? = null
 
-    override fun enable(context: Context, streamInfo: StreamInfo) {
-        super.enable(context, streamInfo)
+    override fun enableInternal() {
+        super.enableInternal()
         recordingThread.startRecording()
     }
 
-    override fun disable() {
-        super.disable()
+    override fun disableInternal() {
+        super.disableInternal()
         recordingThread.stopRecording()
     }
 

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/AudioComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/AudioComponent.kt
@@ -15,7 +15,9 @@ open class AudioComponent : StreamComponent<BaseAudioRetriever, BaseAudioProcess
         super.onInitializeComponent(applicationContext, bundle)
         bundle!!
         processor = AudioProcessorFactory.findProcessor(bundle) ?: throw IllegalArgumentException("unable to resolve audio processor")
+        processor.onInitializeComponent(applicationContext, bundle)
         retriever = AudioRetrieverFactory.findRetriever(bundle) ?: throw IllegalArgumentException("unable to resolve audio retriever")
+        retriever.onInitializeComponent(applicationContext, bundle)
     }
 
     override fun doWorkLoop() {

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamComponent.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Bundle
 import android.os.Message
 import kotlinx.coroutines.runBlocking
+import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.enums.ComponentType
 import org.btelman.controlsdk.models.Component
 import org.btelman.controlsdk.streaming.models.StreamInfo
@@ -64,6 +65,10 @@ abstract class StreamComponent<R : StreamSubComponent,P : StreamSubComponent> : 
 
     fun updateLoop(){
         push(FRAME_FETCH)
+    }
+
+    override fun getInitialStatus(): ComponentStatus {
+        return ComponentStatus.STABLE
     }
 
     override fun getType(): ComponentType {

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamSubComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamSubComponent.kt
@@ -1,5 +1,6 @@
 package org.btelman.controlsdk.streaming.components
 
+import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.enums.ComponentType
 import org.btelman.controlsdk.models.Component
 import org.btelman.controlsdk.streaming.models.StreamInfo
@@ -15,6 +16,10 @@ abstract class StreamSubComponent : Component() {
 
     override fun getType(): ComponentType {
         return ComponentType.STREAMING
+    }
+
+    override fun getInitialStatus(): ComponentStatus {
+        return ComponentStatus.CONNECTING
     }
 
     override fun enableInternal() {

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamSubComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/StreamSubComponent.kt
@@ -1,24 +1,27 @@
 package org.btelman.controlsdk.streaming.components
 
-import android.content.Context
-import androidx.annotation.CallSuper
+import org.btelman.controlsdk.enums.ComponentType
+import org.btelman.controlsdk.models.Component
 import org.btelman.controlsdk.streaming.models.StreamInfo
 
 /**
  * Class that all video or audio sub-components will use
  */
-abstract class StreamSubComponent {
-    protected var context: Context? = null
-
-    /**
-     * Enable the component. Due to the nature of storing context locally, force classes to call super
-     */
-    @CallSuper
-    open fun enable(context: Context, streamInfo: StreamInfo){
-        this.context = context
+abstract class StreamSubComponent : Component() {
+    protected var streamInfo: StreamInfo? = null
+    open fun updateStreamInfo(streamInfo: StreamInfo){
+        this.streamInfo = streamInfo
     }
 
-    open fun disable(){
+    override fun getType(): ComponentType {
+        return ComponentType.STREAMING
+    }
 
+    override fun enableInternal() {
+        //intentionally empty
+    }
+
+    override fun disableInternal() {
+        //intentionally empty
     }
 }

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/VideoComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/components/VideoComponent.kt
@@ -30,7 +30,10 @@ open class VideoComponent : StreamComponent<BaseVideoRetriever, BaseVideoProcess
         super.onInitializeComponent(applicationContext, bundle)
         bundle!!
         processor = VideoProcessorFactory.findProcessor(bundle) ?: throw IllegalArgumentException("unable to resolve video processor")
+        processor.onInitializeComponent(applicationContext, bundle)
+
         retriever = VideoRetrieverFactory.findRetriever(bundle) ?: throw IllegalArgumentException("unable to resolve video retriever")
+        retriever.onInitializeComponent(applicationContext, bundle)
         setLoopMode()
         targetFPS = bundle.getInt(VIDEO_FRAMERATE_LOOP, 30)
         sendStaleFramesWhenStarved = bundle.getBoolean(VIDEO_SEND_STALE_FRAMES_WHEN_STARVED, false)

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/processors/FFmpegVideoProcessor.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/processors/FFmpegVideoProcessor.kt
@@ -1,6 +1,5 @@
 package org.btelman.controlsdk.streaming.video.processors
 
-import android.content.Context
 import android.graphics.Rect
 import android.util.Log
 import org.btelman.controlsdk.enums.ComponentStatus
@@ -14,17 +13,14 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Process frames via FFmpeg
  */
 open class FFmpegVideoProcessor : BaseVideoProcessor(){
-    private var status: ComponentStatus = ComponentStatus.DISABLED
     private val streaming = AtomicBoolean(false)
     private val ffmpegRunning = AtomicBoolean(false)
     private var successCounter = 0
-    private var streamInfo: StreamInfo? = null
     var process : Process? = null
 
-    override fun enable(context: Context, streamInfo: StreamInfo) {
-        super.enable(context, streamInfo)
-        this.streamInfo = streamInfo
-        FFmpegUtil.initFFmpeg(context){ success ->
+    override fun enableInternal() {
+        super.enableInternal()
+        FFmpegUtil.initFFmpeg(context!!){ success ->
             streaming.set(success)
             if(!success){
                 throw ExceptionInInitializerError("Unable to stream : FFMpeg Not Supported on this device")
@@ -32,8 +28,8 @@ open class FFmpegVideoProcessor : BaseVideoProcessor(){
         }
     }
 
-    override fun disable() {
-        super.disable()
+    override fun disableInternal() {
+        super.disableInternal()
         streamInfo = null
         streaming.set(false)
         FFmpegUtil.killFFmpeg(process)

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
@@ -6,8 +6,9 @@ import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.os.Build
 import android.util.Log
+import androidx.annotation.RequiresApi
+import kotlinx.coroutines.runBlocking
 import org.btelman.controlsdk.streaming.models.ImageDataPacket
-import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
 import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTextureComponent
 
@@ -17,28 +18,39 @@ import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTex
  * still supported, but may not work on every device
  * ex. Samsung Galaxy S4
  */
-class CameraCompatRetriever : BaseVideoRetriever(){
+open class CameraCompatRetriever : BaseVideoRetriever(){
     private var retriever : BaseVideoRetriever? = null
 
     override fun grabImageData(): ImageDataPacket? {
         return retriever?.grabImageData()
     }
 
-    override fun enable(context: Context, streamInfo: StreamInfo) {
-        super.enable(context, streamInfo)
-        val cameraInfo = streamInfo.deviceInfo
+    override fun enableInternal() {
+        super.enableInternal()
+        val cameraInfo = streamInfo!!.deviceInfo
         val cameraId = cameraInfo.getCameraId()
         if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
-            && validateCamera2Support(context, cameraId)){
+            && validateCamera2Support(context!!, cameraId)){
             Log.d("CameraRetriever", "Using Camera2 API")
-            retriever = Camera2SurfaceTextureComponent()
+            retriever = createCamera2()
         }
         else{
             Log.d("CameraRetriever",
                 "Using Camera1 API. Device API too low or LIMITED capabilities")
-            retriever = Camera1SurfaceTextureComponent()
+            retriever = createCamera1()
         }
-        retriever?.enable(context, streamInfo)
+        runBlocking {
+            retriever?.enable()?.await()
+        }
+    }
+
+    private fun createCamera1(): BaseVideoRetriever? {
+        return Camera1SurfaceTextureComponent()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    protected open fun createCamera2(): BaseVideoRetriever? {
+        return Camera2SurfaceTextureComponent()
     }
 
     override fun listenForFrame(func: () -> Unit) {
@@ -49,9 +61,11 @@ class CameraCompatRetriever : BaseVideoRetriever(){
         retriever?.removeListenerForFrame()
     }
 
-    override fun disable() {
-        super.disable()
-        retriever?.disable()
+    override fun disableInternal() {
+        super.disableInternal()
+        runBlocking {
+            retriever?.disable()?.await()
+        }
         retriever = null
     }
 

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/CameraCompatRetriever.kt
@@ -10,7 +10,7 @@ import androidx.annotation.RequiresApi
 import kotlinx.coroutines.runBlocking
 import org.btelman.controlsdk.streaming.models.ImageDataPacket
 import org.btelman.controlsdk.streaming.video.retrievers.api16.Camera1SurfaceTextureComponent
-import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2SurfaceTextureComponent
+import org.btelman.controlsdk.streaming.video.retrievers.api21.Camera2Component
 
 /**
  * Handle compatibility between camera1 and camera2 usage, since some api21 devices are
@@ -50,7 +50,7 @@ open class CameraCompatRetriever : BaseVideoRetriever(){
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     protected open fun createCamera2(): BaseVideoRetriever? {
-        return Camera2SurfaceTextureComponent()
+        return Camera2Component()
     }
 
     override fun listenForFrame(func: () -> Unit) {

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/SurfaceTextureVideoRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/SurfaceTextureVideoRetriever.kt
@@ -1,6 +1,5 @@
 package org.btelman.controlsdk.streaming.video.retrievers
 
-import android.content.Context
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.utils.EglCore
 import org.btelman.controlsdk.streaming.utils.SurfaceTextureUtils
@@ -22,17 +21,16 @@ abstract class SurfaceTextureVideoRetriever : BaseVideoRetriever() {
         eglCore = EglCore()
     }
 
-    override fun enable(context: Context, streamInfo: StreamInfo) {
-        super.enable(context, streamInfo)
-
-        eglSurface = eglCore?.createOffscreenSurface(streamInfo.width, streamInfo.height)
+    override fun enableInternal() {
+        super.enableInternal()
+        eglSurface = eglCore?.createOffscreenSurface(streamInfo!!.width, streamInfo!!.height)
         eglCore?.makeCurrent(eglSurface)
         mStManager = SurfaceTextureUtils.SurfaceTextureManager()
         setupCamera(streamInfo)
     }
 
-    override fun disable() {
-        super.disable()
+    override fun disableInternal() {
+        super.disableInternal()
         releaseCamera()
         mStManager?.surfaceTexture?.release()
         eglCore?.releaseSurface(eglSurface)

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/SurfaceTextureVideoRetriever.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/SurfaceTextureVideoRetriever.kt
@@ -1,6 +1,5 @@
 package org.btelman.controlsdk.streaming.video.retrievers
 
-import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.utils.EglCore
 import org.btelman.controlsdk.streaming.utils.SurfaceTextureUtils
 import javax.microedition.khronos.egl.EGLSurface
@@ -11,7 +10,7 @@ import javax.microedition.khronos.egl.EGLSurface
  * Compatible down to API16
  */
 abstract class SurfaceTextureVideoRetriever : BaseVideoRetriever() {
-    protected abstract fun setupCamera(streamInfo: StreamInfo? = null)
+    protected abstract fun setupCamera()
     protected abstract fun releaseCamera()
     protected var eglCore: EglCore? = null
     protected var eglSurface: EGLSurface? = null
@@ -26,7 +25,7 @@ abstract class SurfaceTextureVideoRetriever : BaseVideoRetriever() {
         eglSurface = eglCore?.createOffscreenSurface(streamInfo!!.width, streamInfo!!.height)
         eglCore?.makeCurrent(eglSurface)
         mStManager = SurfaceTextureUtils.SurfaceTextureManager()
-        setupCamera(streamInfo)
+        setupCamera()
     }
 
     override fun disableInternal() {

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -5,7 +5,6 @@ import android.graphics.Rect
 import android.hardware.Camera
 import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.streaming.models.ImageDataPacket
-import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.SurfaceTextureVideoRetriever
 
 /**
@@ -52,7 +51,7 @@ open class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Came
         camera = null
     }
 
-    override fun setupCamera(streamInfo : StreamInfo?){
+    override fun setupCamera(){
         val cameraId = streamInfo?.deviceInfo?.getCameraId() ?: 0
         camera ?: run {
             if(cameraId+1 > Camera.getNumberOfCameras()){

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api16/Camera1SurfaceTextureComponent.kt
@@ -3,6 +3,7 @@ package org.btelman.controlsdk.streaming.video.retrievers.api16
 import android.graphics.ImageFormat
 import android.graphics.Rect
 import android.hardware.Camera
+import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.streaming.models.ImageDataPacket
 import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.SurfaceTextureVideoRetriever
@@ -17,7 +18,7 @@ import org.btelman.controlsdk.streaming.video.retrievers.SurfaceTextureVideoRetr
  * Does not support USB webcams
  */
 @Suppress("DEPRECATION")
-class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.PreviewCallback{
+open class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.PreviewCallback{
     private var supportedPreviewSizes: MutableList<Camera.Size>? = null
     private var r: Rect? = null
     private var camera : Camera? = null
@@ -51,29 +52,40 @@ class Camera1SurfaceTextureComponent : SurfaceTextureVideoRetriever(), Camera.Pr
         camera = null
     }
 
-    override fun setupCamera(streamInfo : StreamInfo?){ //TODO actually use resolution from here?
+    override fun setupCamera(streamInfo : StreamInfo?){
         val cameraId = streamInfo?.deviceInfo?.getCameraId() ?: 0
-        val cameraWidth = streamInfo?.width ?: 640
-        val cameraHeight = streamInfo?.height ?: 480
         camera ?: run {
-            if(cameraId+1 > Camera.getNumberOfCameras())
-                throw Exception("Attempted to open camera $cameraId. " +
-                        "Only ${Camera.getNumberOfCameras()} cameras exist! 0 is first camera")
+            if(cameraId+1 > Camera.getNumberOfCameras()){
+                val e = Exception("Attempted to open camera $cameraId. Only ${Camera.getNumberOfCameras()} cameras exist! 0 is first camera")
+                log.e("Error opening camera", e)
+                status = ComponentStatus.ERROR
+                throw e
+            }
             camera = Camera.open(cameraId)
             camera?.setDisplayOrientation(90)
         }
         camera?.let {
-            val p = it.parameters
-            if(!validateSizeSupported(p, cameraWidth, cameraHeight))
-                throw java.lang.Exception("Camera size " +
-                        "${cameraWidth}x$cameraHeight not supported by this camera!")
-            p.setPreviewSize(cameraWidth, cameraHeight)
-            p.setRecordingHint(true)
-            it.parameters = p
+            it.parameters = updateCameraParams(it.parameters)
             it.setPreviewTexture(mStManager?.surfaceTexture)
             it.setPreviewCallback(this)
             it.startPreview()
         }
+        status = ComponentStatus.STABLE
+    }
+
+    open fun updateCameraParams(parameters : Camera.Parameters) : Camera.Parameters{
+        val cameraWidth = streamInfo?.width ?: 640
+        val cameraHeight = streamInfo?.height ?: 480
+        if(!validateSizeSupported(parameters, cameraWidth, cameraHeight)){
+            val e = java.lang.Exception("Camera size " +
+                    "${cameraWidth}x$cameraHeight not supported by this camera!")
+            log.e("Failed to use width=$cameraWidth and height=$cameraHeight for camera!", e)
+            status = ComponentStatus.ERROR
+            throw e
+        }
+        parameters.setPreviewSize(cameraWidth, cameraHeight)
+        parameters.setRecordingHint(true)
+        return parameters
     }
 
     private fun validateSizeSupported(p: Camera.Parameters?, cameraWidth: Int, cameraHeight: Int) : Boolean{

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2Component.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2Component.kt
@@ -13,7 +13,6 @@ import androidx.annotation.NonNull
 import androidx.annotation.RequiresApi
 import org.btelman.controlsdk.enums.ComponentStatus
 import org.btelman.controlsdk.streaming.models.ImageDataPacket
-import org.btelman.controlsdk.streaming.models.StreamInfo
 import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
 
 
@@ -71,7 +70,7 @@ open class Camera2Component : BaseVideoRetriever(), ImageReader.OnImageAvailable
 
     override fun enableInternal() {
         super.enableInternal()
-        setupCamera(streamInfo)
+        setupCamera()
     }
 
     override fun disableInternal() {
@@ -80,7 +79,7 @@ open class Camera2Component : BaseVideoRetriever(), ImageReader.OnImageAvailable
     }
 
     @SuppressLint("MissingPermission") //Already handled. No way to call this
-    protected open fun setupCamera(streamInfo : StreamInfo?) {
+    protected open fun setupCamera() {
         startBackgroundThread()
         width = streamInfo?.width ?: 640
         height = streamInfo?.height ?: 640

--- a/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2Component.kt
+++ b/sdk/streaming/src/main/java/org/btelman/controlsdk/streaming/video/retrievers/api21/Camera2Component.kt
@@ -21,7 +21,7 @@ import org.btelman.controlsdk.streaming.video.retrievers.BaseVideoRetriever
  */
 @Suppress("MemberVisibilityCanBePrivate")
 @RequiresApi(21)
-open class Camera2SurfaceTextureComponent : BaseVideoRetriever(), ImageReader.OnImageAvailableListener {
+open class Camera2Component : BaseVideoRetriever(), ImageReader.OnImageAvailableListener {
 
     private var data: ByteArray? = null
     protected var width = 0


### PR DESCRIPTION
- API Update: Camera2TextureComponent.kt updated to Camera2Component.kt
- API Update: StreamSubComponent is now an extension of Component. Code changes will have to be made if this was used for custom classes. 

    - `override fun enable(context: Context, streamInfo: StreamInfo)` now becomes `override fun enableInternal()`. streamInfo and context are set in onInitializeComponent automatically

    - `override fun disable()` now becomes `override fun disableInternal()`

- CommunicationDriverComponent now broadcasts its status on the service level to the main service handler
- Video subcomponents (including camera) now can broadcast status on the service level to the main service handler
- Audio subcomponents now can broadcast status on the service level to the main service handler

Camera changes:
- Camera2Component.kt updated to not override SurfaceTextureVideoRetriever.kt
- Camera2Component.kt is now overridable, and some functions can be overridden
- CameraCompatRetriever able to be overridden now, and has open functions for initializing either a camera1 class or a camera2 class



